### PR TITLE
feat: add `get_issue_count` method

### DIFF
--- a/bot/exts/utilities/githubstats.py
+++ b/bot/exts/utilities/githubstats.py
@@ -2,24 +2,30 @@ from discord.ext.commands import Cog, command, Context
 from bot.constants import Tokens
 from bot.bot import Bot
 
+GITHUB_API_URL = "https://api.github.com"
+
 
 class GitHubStats(Cog):
     def __init__(self, bot: Bot) -> None:
         self.bot = bot
 
     @command(name="gh-stats")
-    async def ping(self, ctx: Context, repo: str = "python-discord/bot") -> None:
+    async def github_stats(self, ctx: Context, start: str, end: str, repo: str = "python-discord/sir-lancebot") -> None:
         """
         Fetches stats for a GitHub repo.
         Usage: !github_stats 2023-01-01 2023-12-31 python-discord/bot
         """
-        await ctx.send("Tormod's Crypt: Draw a card. If you can't, you did. No you didn't.")
-
         if not await self.repo_exists(repo):
-            await ctx.send(f"Could not find repository: `{repo}`")  # TODO: add emojis as common for discord bots
+            await ctx.send(f"❌ Could not find repository: `{repo}`")
             return
 
-        await ctx.send(f"Found repo: `{repo}`")
+        open = await self.get_issue_count(repo, start, end, state="created")
+        closed = await self.get_issue_count(repo, start, end, state="closed")
+
+        stats_message = (
+            f"Stats for **{repo}** ({start} to {end}):\n" f"Issues opened: {open}\n" f"Issues closed: {closed}"
+        )
+        await ctx.send(stats_message)
 
     async def repo_exists(self, repo: str) -> bool:
         """
@@ -28,11 +34,36 @@ class GitHubStats(Cog):
         Args:
             repo (str): The repository name in 'owner/repo' format (e.g., 'python-discord/bot').
         """
-        url = f"https://api.github.com/repos/{repo}"
+        url = f"{GITHUB_API_URL}/repos/{repo}"
         headers = {"Authorization": f"token {Tokens.github.get_secret_value()}"}
 
         async with self.bot.http_session.get(url, headers=headers) as response:
             return response.status == 200
+
+    async def get_issue_count(self, repo: str, start: str, end: str, state: str) -> int:
+        """
+        Gets the number of issues opened or closed (based on state) in a given timeframe.
+
+        Args:
+            repo (str): The repository name in 'owner/repo' format (e.g., 'python-discord/bot').
+            start (str): The start date (e.g., 2023-01-01).
+            end (str): The end date (e.g., 2023-12-31).
+            state (str): The state of the issue (created/closed)
+        """
+        url = f"{GITHUB_API_URL}/search/issues"
+        headers = {"Authorization": f"token {Tokens.github.get_secret_value()}"}
+
+        # The query string uses GitHub's advanced search syntax
+        # e.g., repo:python-discord/bot is:issue created:2023-01-01..2023-12-31
+        query = f"repo:{repo} is:issue {state}:{start}..{end}"
+        params = {"q": query}
+
+        async with self.bot.http_session.get(url, headers=headers, params=params) as response:
+            if response.status != 200:
+                return 0
+
+            data = await response.json()
+            return data.get("total_count", 0)
 
 
 async def setup(bot: Bot) -> None:

--- a/bot/exts/utilities/githubstats.py
+++ b/bot/exts/utilities/githubstats.py
@@ -7,7 +7,7 @@ class GitHubStats(Cog):
     def __init__(self, bot: Bot) -> None:
         self.bot = bot
 
-    @command(name="github_stats")
+    @command(name="gh-stats")
     async def ping(self, ctx: Context, repo: str = "python-discord/bot") -> None:
         """
         Fetches stats for a GitHub repo.

--- a/bot/exts/utilities/githubstats.py
+++ b/bot/exts/utilities/githubstats.py
@@ -60,7 +60,7 @@ class GitHubStats(Cog):
 
         async with self.bot.http_session.get(url, headers=headers, params=params) as response:
             if response.status != 200:
-                return 0
+                return -1
 
             data = await response.json()
             return data.get("total_count", 0)


### PR DESCRIPTION
This will fetch the issue count depending on the state and print out the stats like so:

```
Stats for oskarnurm/koda.nvim (2025-01-01 to 2026-02-26):
Issues opened: 26
Issues closed: 24
```

Also, renamed the file from `github_stats` to `githubstats` per the project's convention.

Closes #5 
